### PR TITLE
Enable registry-proxy for CNI users

### DIFF
--- a/charts/registry-proxy/templates/registry-proxy-daemon.yaml
+++ b/charts/registry-proxy/templates/registry-proxy-daemon.yaml
@@ -19,6 +19,9 @@ spec:
         heritage: deis
         app: deis-registry-proxy
     spec:
+{{- if (.Values.global.use_cni) }}
+      hostNetwork: true
+{{- end}}
       containers:
       - name: deis-registry-proxy
         image: quay.io/{{.Values.org}}/registry-proxy:{{.Values.docker_tag}}
@@ -38,7 +41,15 @@ spec:
           value: $(DEIS_REGISTRY_SERVICE_HOST)
         - name: REGISTRY_PORT
           value: $(DEIS_REGISTRY_SERVICE_PORT)
+        - name: BIND_ADDR
+{{- if (.Values.global.use_cni) }}
+          value: {{ default "127.0.0.1:5555" .Values.global.registry_proxy_bind_addr | quote }}
+{{- else }}
+          value: {{ default "80" .Values.global.registry_proxy_bind_addr | quote }}
+{{- end }}
+{{- if not (.Values.global.use_cni) }}
         ports:
         - containerPort: 80
           hostPort: {{.Values.global.host_port}}
+{{- end }}
 {{- end }}

--- a/charts/registry-proxy/values.yaml
+++ b/charts/registry-proxy/values.yaml
@@ -15,3 +15,13 @@ global:
   registry_location: "on-cluster"
   # The host port to which registry proxy binds to
   host_port: 5555
+  # Set the `listen` variable for registry-proxy's NGINX
+  #
+  # Valid values are:
+  # - 80: If you're on flannel or kubenet
+  # - 127.0.0.1:5555: If you're with CNI
+  #
+  # In case of CNI you can not use `hostPort` notation due to https://github.com/kubernetes/kubernetes/issues/23920
+  # registry_proxy_bind_addr: "80"
+  # If the Kubernetes cluster uses CNI
+  # use_cni: true

--- a/rootfs/bin/boot
+++ b/rootfs/bin/boot
@@ -3,14 +3,14 @@
 # fail if no hostname is provided
 REGISTRY_HOST=${REGISTRY_HOST:?no host}
 REGISTRY_PORT=${REGISTRY_PORT:-80}
+BIND_ADDR=${BIND_ADDR:-80}
 
 # we are always listening on port 80
 # https://github.com/nginxinc/docker-nginx/blob/43c112100750cbd1e9f2160324c64988e7920ac9/stable/jessie/Dockerfile#L25
-PORT=80
 
 sed -e "s/%HOST%/$REGISTRY_HOST/g" \
 	-e "s/%PORT%/$REGISTRY_PORT/g" \
-	-e "s/%BIND_PORT%/$PORT/g" \
+	-e "s/%BIND_PORT%/$BIND_ADDR/g" \
 	</etc/nginx/conf.d/default.conf.in >/etc/nginx/conf.d/default.conf
 
 # wait for registry to come online


### PR DESCRIPTION
Variables added:

- `global.use_cni` - Boolean, disabled by default
- `global.registry_proxy_bind_addr` - String, default `80`

Proofing image: `quay.io/evilmartians/deis-registry-proxy:cni`

Steps to setup:

    kubectl delete ds -n deis deis-registry-proxy
    helm install -n proxy --namespace=deis ./charts/registry-proxy --set global.registry_proxy_bind_addr=127.0.0.1:6666,global.use_cni=true

PR for https://github.com/deis/workflow is on a way.